### PR TITLE
Pexels APIを呼び出すためのAPIクライアントを実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
+
+Config.xcconfig

--- a/PexelsPackage/Sources/Data/APIClient.swift
+++ b/PexelsPackage/Sources/Data/APIClient.swift
@@ -1,0 +1,86 @@
+//
+//  File.swift
+//  PexelsPackage
+//
+//  Created by air2 on 2025/10/07.
+//
+
+import ComposableArchitecture
+import Foundation
+import Alamofire
+
+@DependencyClient
+public struct PexelsAPIClient: Sendable {
+    // 写真を検索する
+    public var searchPhotos: @Sendable (SearchPhotosRequest) async throws -> PexelsSearchResponse
+}
+
+extension PexelsAPIClient: DependencyKey {
+    public static var liveValue: Self {
+        let apiKey = ""
+        let baseURL = URL(string: "https://api.pexels.com/v1")!
+        let session = Session.default
+        
+        return Self(
+            searchPhotos: { request in
+                try await performRequest(
+                    path: request.path,
+                    method: request.method,
+                    queryParameters: request.queryParameters,
+                    baseURL: baseURL,
+                    apiKey: apiKey,
+                    session: session
+                )
+            }
+        )
+    }
+    
+    private static func performRequest<T: Decodable & Sendable>(
+        path: String,
+        method: HTTPMethod,
+        queryParameters: [String: Any]?,
+        baseURL: URL,
+        apiKey: String,
+        session: Session
+    ) async throws -> T {
+        var url = baseURL.appendingPathComponent(path)
+        
+        if let queryParams = queryParameters {
+            var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+            components?.queryItems = queryParams.map { key, value in
+                URLQueryItem(name: key, value: "\(value)")
+            }
+            if let urlWithQuery = components?.url {
+                url = urlWithQuery
+            }
+        }
+        
+        let headers: HTTPHeaders = [
+            "Authorization": apiKey
+        ]
+        
+        let response = await session.request(
+            url,
+            method: method,
+            headers: headers
+        )
+        .validate()
+        .serializingDecodable(T.self)
+        .response
+        
+        switch response.result {
+        case .success(let data):
+            return data
+            
+        case .failure(let error):
+            throw error
+        }
+    }
+}
+
+extension DependencyValues {
+    public var pexelsAPIClient: PexelsAPIClient {
+        get { self[PexelsAPIClient.self] }
+        set { self[PexelsAPIClient.self] = newValue }
+    }
+}

--- a/PexelsPackage/Sources/Data/APIClient.swift
+++ b/PexelsPackage/Sources/Data/APIClient.swift
@@ -11,24 +11,29 @@ import Alamofire
 
 @DependencyClient
 public struct PexelsAPIClient: Sendable {
+    // 初期化する
+    public var initialize: @Sendable (String) -> Void
     // 写真を検索する
     public var searchPhotos: @Sendable (SearchPhotosRequest) async throws -> PexelsSearchResponse
 }
 
 extension PexelsAPIClient: DependencyKey {
     public static var liveValue: Self {
-        let apiKey = ""
+        let apiKey = LockIsolated("")
         let baseURL = URL(string: "https://api.pexels.com/v1")!
         let session = Session.default
         
         return Self(
+            initialize: { key in
+                apiKey.setValue(key)
+            },
             searchPhotos: { request in
                 try await performRequest(
                     path: request.path,
                     method: request.method,
                     queryParameters: request.queryParameters,
                     baseURL: baseURL,
-                    apiKey: apiKey,
+                    apiKey: apiKey.value,
                     session: session
                 )
             }

--- a/PexelsPackage/Sources/Data/File.swift
+++ b/PexelsPackage/Sources/Data/File.swift
@@ -1,8 +1,0 @@
-//
-//  File.swift
-//  PexelsPackage
-//
-//  Created by air2 on 2025/10/07.
-//
-
-import Foundation

--- a/PexelsPackage/Sources/Data/Model/PexelsPhoto.swift
+++ b/PexelsPackage/Sources/Data/Model/PexelsPhoto.swift
@@ -1,0 +1,49 @@
+//
+//  File.swift
+//  PexelsPackage
+//
+//  Created by air2 on 2025/10/07.
+//
+
+import Foundation
+
+// Photoオブジェクト
+public struct PexelsPhoto: Codable, Sendable, Identifiable {
+    public let id: Int
+    public let width: Int
+    public let height: Int
+    public let url: String
+    public let photographer: String
+    public let photographerUrl: String
+    public let photographerId: Int
+    public let avgColor: String
+    public let src: PexelsPhotoSource
+    public let liked: Bool
+    public let alt: String
+    
+    enum CodingKeys: String, CodingKey {
+        case id, width, height, url, photographer
+        case photographerUrl = "photographer_url"
+        case photographerId = "photographer_id"
+        case avgColor = "avg_color"
+        case src, liked, alt
+    }
+}
+
+// PhotoSrc
+public struct PexelsPhotoSource: Codable, Sendable {
+    public let original: String
+    public let large2x: String
+    public let large: String
+    public let medium: String
+    public let small: String
+    public let portrait: String
+    public let landscape: String
+    public let tiny: String
+    
+    enum CodingKeys: String, CodingKey {
+        case original
+        case large2x = "large2x"
+        case large, medium, small, portrait, landscape, tiny
+    }
+}

--- a/PexelsPackage/Sources/Data/Request/SearchPhotosRequest.swift
+++ b/PexelsPackage/Sources/Data/Request/SearchPhotosRequest.swift
@@ -1,0 +1,62 @@
+//
+//  File.swift
+//  PexelsPackage
+//
+//  Created by air2 on 2025/10/07.
+//
+
+import Foundation
+import Alamofire
+
+// 検索リクエスト
+public struct SearchPhotosRequest: Sendable {
+    public let query: String
+    public let page: Int
+    public let perPage: Int
+    public let orientation: String?
+    public let size: String?
+    public let color: String?
+    public let locale: String?
+    
+    public init(
+        query: String,
+        page: Int = 1,
+        perPage: Int = 15,
+        orientation: String? = nil,
+        size: String? = nil,
+        color: String? = nil,
+        locale: String? = nil
+    ) {
+        self.query = query
+        self.page = page
+        self.perPage = perPage
+        self.orientation = orientation
+        self.size = size
+        self.color = color
+        self.locale = locale
+    }
+    
+    var path: String { "/search" }
+    var method: HTTPMethod { .get }
+    
+    var queryParameters: [String: Any] {
+        var params: [String: Any] = [
+            "query": query,
+            "page": page,
+            "per_page": perPage
+        ]
+        if let orientation = orientation {
+            params["orientation"] = orientation
+        }
+        if let size = size {
+            params["size"] = size
+        }
+        if let color = color {
+            params["color"] = color
+        }
+        if let locale = locale {
+            params["locale"] = locale
+        }
+        return params
+    }
+}

--- a/PexelsPackage/Sources/Data/Response/PexelsSearchResponse.swift
+++ b/PexelsPackage/Sources/Data/Response/PexelsSearchResponse.swift
@@ -1,0 +1,25 @@
+//
+//  File.swift
+//  PexelsPackage
+//
+//  Created by air2 on 2025/10/07.
+//
+
+import Foundation
+
+// 検索結果
+public struct PexelsSearchResponse: Codable, Sendable {
+    public let page: Int
+    public let perPage: Int
+    public let photos: [PexelsPhoto]
+    public let totalResults: Int
+    public let nextPage: String?
+    
+    enum CodingKeys: String, CodingKey {
+        case page
+        case perPage = "per_page"
+        case photos
+        case totalResults = "total_results"
+        case nextPage = "next_page"
+    }
+}

--- a/PexelsPackage/Sources/Feature/Search/PexelesSearchView.swift
+++ b/PexelsPackage/Sources/Feature/Search/PexelesSearchView.swift
@@ -6,6 +6,8 @@
 //
 
 import Foundation
+import PexelsModuleData
+import ComposableArchitecture
 import SwiftUI
 
 public struct PexelesSearchView: View {
@@ -13,6 +15,17 @@ public struct PexelesSearchView: View {
     public init() {}
     
     public var body: some View {
-        Text("PexelesSearchView")
+        VStack {
+            Text("PexelesSearchView")
+        }
+        .task {
+            @Dependency(\.pexelsAPIClient) var apiClient
+            do {
+                let results = try await apiClient.searchPhotos(.init(query: "Flowers"))
+                print(results)
+            } catch {
+                print("error: \(error)")
+            }
+        }
     }
 }

--- a/PexelsViewer/PexelsViewer.xcodeproj/project.pbxproj
+++ b/PexelsViewer/PexelsViewer.xcodeproj/project.pbxproj
@@ -14,9 +14,34 @@
 		4BC9F1FD2E94D92400CAA2DF /* PexelsViewer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PexelsViewer.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		4BDF19142E94FE9C005F2CBF /* Exceptions for "PexelsViewer" folder in "PexelsViewer" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Config/Config.xcconfig,
+				Info.plist,
+			);
+			target = 4BC9F1FC2E94D92400CAA2DF /* PexelsViewer */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet section */
+		4BDF19152E94FE9C005F2CBF /* Exceptions for "PexelsViewer" folder in "Compile Sources" phase from "PexelsViewer" target */ = {
+			isa = PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet;
+			buildPhase = 4BC9F1F92E94D92400CAA2DF /* Sources */;
+			membershipExceptions = (
+				Config/Config.xcconfig,
+			);
+		};
+/* End PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		4BC9F1FF2E94D92400CAA2DF /* PexelsViewer */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				4BDF19142E94FE9C005F2CBF /* Exceptions for "PexelsViewer" folder in "PexelsViewer" target */,
+				4BDF19152E94FE9C005F2CBF /* Exceptions for "PexelsViewer" folder in "Compile Sources" phase from "PexelsViewer" target */,
+			);
 			path = PexelsViewer;
 			sourceTree = "<group>";
 		};
@@ -260,6 +285,8 @@
 		};
 		4BC9F20C2E94D92400CAA2DF /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 4BC9F1FF2E94D92400CAA2DF /* PexelsViewer */;
+			baseConfigurationReferenceRelativePath = Config/Config.xcconfig;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -269,6 +296,9 @@
 				DEVELOPMENT_TEAM = AQFMTW7DW4;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = PexelsViewer/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "";
+				INFOPLIST_KEY_LSApplicationCategoryType = "";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -290,6 +320,8 @@
 		};
 		4BC9F20D2E94D92400CAA2DF /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 4BC9F1FF2E94D92400CAA2DF /* PexelsViewer */;
+			baseConfigurationReferenceRelativePath = Config/Config.xcconfig;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -299,6 +331,9 @@
 				DEVELOPMENT_TEAM = AQFMTW7DW4;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = PexelsViewer/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "";
+				INFOPLIST_KEY_LSApplicationCategoryType = "";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/PexelsViewer/PexelsViewer/Info.plist
+++ b/PexelsViewer/PexelsViewer/Info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key></key>
+	<string></string>
+	<key>PEXELS_API_KEY</key>
+	<string>$(PEXELS_API_KEY)</string>
+</dict>
+</plist>

--- a/PexelsViewer/PexelsViewer/PexelsViewerApp.swift
+++ b/PexelsViewer/PexelsViewer/PexelsViewerApp.swift
@@ -5,10 +5,30 @@
 //  Created by air2 on 2025/10/07.
 //
 
+import ComposableArchitecture
+import PexelsModuleData
 import SwiftUI
+
+class AppDelegate: NSObject, UIApplicationDelegate {
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptons: [UIApplication.LaunchOptionsKey : Any]? = nil
+    ) -> Bool {
+        guard let apiKey = Bundle.main.object(forInfoDictionaryKey: "PEXELS_API_KEY") as? String else {
+            return true
+        }
+        
+        @Dependency(\.pexelsAPIClient) var apiClient
+        apiClient.initialize(apiKey)
+        return true
+    }
+}
 
 @main
 struct PexelsViewerApp: App {
+    
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+    
     var body: some Scene {
         WindowGroup {
             ContentView()


### PR DESCRIPTION
## 概要

- SSIA

## 実装

- APIキーの初期化と検索が可能な単純なAPIクライアントを実装
- キーはXCConfigに保存
- 検証実装として検索画面でAPI呼び出しを実装。下記の通りコールに成功している。

```
PexelsSearchResponse(page: 1, perPage: 15, photos: [PexelsModuleData.PexelsPhoto(id: 56866, width: 3008, height: 2000, url: "https://www.pexels.com/photo/close-photography-of-red-and-pink-rose-56866/", photographer: "Pixabay", photographerUrl: "https://www.pexels.com/@pixabay", photographerId: 2659, avgColor: "#533328", src: PexelsModuleData.PexelsPhotoSource(original: "https://images.pexels.com/photos/56866/garden-rose-red-pink-56866.jpeg", large2x: "https://images.pexels.com/photos/56866/garden-rose-red-pink-56866.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940", large: "https://images.pexels.com/photos/56866/garden-rose-red-pink-56866.jpeg?auto=compress&cs=tinysrgb&h=650&w=940", medium: "https://images.pexels.com/photos/56866/garden-rose-red-pink-56866.jpeg?auto=compress&cs=tinysrgb&h=350", small: "https://images.pexels.com/photos/56866/garden-rose-red-pink-56866.jpeg?auto=compress&cs=tinysrgb&h=130", portrait: "https://images.pexels.com/photos/56866/garden-rose-red-pink-56866.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=1200&w=800", landscape: "https://images.pexels.com/photos/56866/garden-rose-red-pink-56866.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=627&w=1200", tiny: "https://images.pexels.com/photos/56866/garden-rose-red-pink-56866.jpeg?auto=compress&cs=tinysrgb&dpr=1&fit=crop&h=200&w=280"), liked: false, alt: "Vibrant red rose with fresh dewdrops, captured in a blooming garden setting.")
```